### PR TITLE
chore: allow Railway host

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,37 +23,15 @@ export default defineConfig((config) => {
       host: true,
       port: 5173,
       strictPort: false,
+      allowedHosts: true,
     },
     preview: {
       host: true,
       port: 5173,
       strictPort: false,
+      allowedHosts: true,
     },
     plugins: [
-      // CUSTOM PLUGIN TO FORCE ALLOWEDHOSTS
-      {
-        name: 'force-allowed-hosts',
-        configureServer(server: ViteDevServer) {
-          // Override the allowedHosts check completely
-          const originalCheckHost = server.middlewares.use;
-          server.middlewares.use = function(path: any, ...args: any[]) {
-            if (typeof path === 'function') {
-              const middleware = path;
-              const wrappedMiddleware = (req: any, res: any, next: any) => {
-                // Skip host checking entirely
-                return middleware(req, res, next);
-              };
-              return originalCheckHost.call(this, wrappedMiddleware, ...args);
-            }
-            return originalCheckHost.call(this, path, ...args);
-          };
-          
-          // Also set the allowedHosts directly
-          if (server.config.server) {
-            server.config.server.allowedHosts = 'all';
-          }
-        },
-      },
       nodePolyfills({
         include: ['buffer', 'process', 'util', 'stream'],
         globals: {


### PR DESCRIPTION
## Summary
- allow any incoming host for dev and preview by setting `allowedHosts: true`
- drop custom host-override plugin from Vite config

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm run build` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b5743a857c832fad26295211644370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility in development and preview environments by allowing connections from various hostnames without “invalid host” errors.
  * Ensures more reliable preview links and local network testing.

* **Chores**
  * Simplified server configuration by adopting the platform’s built-in allowed hosts setting.
  * Removed a custom workaround to reduce maintenance and potential conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->